### PR TITLE
fix: Binding to multicast socket fails in iOS >= 11.0

### DIFF
--- a/lib/upnp.dart
+++ b/lib/upnp.dart
@@ -3,6 +3,7 @@ library upnp;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:xml/xml.dart';


### PR DESCRIPTION
According to Binding to multicast socket fails in iOS >= 11.0
https://github.com/dart-lang/sdk/issues/42250